### PR TITLE
Add code highlighting with highlight.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5863,6 +5863,11 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6150,6 +6155,12 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
+    },
+    "ignore-styles": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-styles/-/ignore-styles-5.0.1.tgz",
+      "integrity": "sha1-tJ7yJ0va/NikiAqWa/440aC/RnE=",
       "dev": true
     },
     "import-local": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "test": "vue-cli-service test",
+    "test": "vue-cli-service test --require ignore-styles",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "highlight.js": "^9.12.0",
     "vue": "^2.5.13"
   },
   "devDependencies": {
@@ -18,6 +19,7 @@
     "@vue/cli-service": "^3.0.0-beta.6",
     "@vue/test-utils": "^1.0.0-beta.10",
     "chai": "^4.1.2",
+    "ignore-styles": "^5.0.1",
     "vue-template-compiler": "^2.5.13"
   },
   "browserslist": [

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@
     </nav>
 
     <main role="main">
-      <Code v-if="body">{{ body }}</Code>
+      <Code v-if="body" :language="language" :code="body"></Code>
       <WelcomeBanner v-else />
     </main>
   </div>
@@ -17,14 +17,27 @@
   import UrlBar from "./components/UrlBar.vue";
   import WelcomeBanner from "./components/WelcomeBanner.vue";
 
+  const subtypeName = (contentType) => contentType.match(/.*\/([^;]*)(;.*)?/)[1];
+
   export default {
-    data: () => ({ url: "", body: "" }),
+    data: () => ({
+      url: "",
+      body: "",
+      language: "",
+      response: undefined
+    }),
     components: { Code, UrlBar, WelcomeBanner },
     watch: {
       url(url) {
         fetch(url, { headers: { Accept: "application/json" } })
-          .then((response) => response.text())
-          .then((body) => this.body = body);
+          .then((response) => this.response = response);
+      },
+      response(response) {
+        response.text()
+          .then((body) => {
+            this.language = subtypeName(this.response.headers.get("content-type"));
+            this.body = body;
+          });
       }
     }
   };

--- a/src/components/Code.vue
+++ b/src/components/Code.vue
@@ -1,14 +1,40 @@
 <template>
-  <div class="code card">
-    <div class="card-body">
-      <p class="card-text"><slot /></p>
+  <div class="code">
+    <div class="card" v-if="language === 'html'">
+      <iframe :srcdoc="highlighted"></iframe>
     </div>
+    <pre class="card" v-else>
+      <code class="hljs" :class="language" v-html="highlighted"></code>
+    </pre>
   </div>
 </template>
 
 <script>
+  import hljs from "highlight.js";
+  import "highlight.js/styles/default.css";
+
+  const formatJson = (json) => JSON.stringify(JSON.parse(json), null, "  ");
+
   export default {
-    name: "Code"
+    name: "Code",
+    props: { code: String, language: String },
+    methods: {
+      highlight(code) {
+        return hljs.highlightAuto(code).value;
+      }
+    },
+    computed: {
+      highlighted() {
+        if (this.language === "html") {
+          return this.code;
+        } else if (this.language === "json") {
+          const formatted = formatJson(this.code);
+          return this.highlight(formatted);
+        } else {
+          return this.highlight(this.code);
+        }
+      }
+    }
   };
 </script>
 
@@ -16,5 +42,11 @@
   .code {
     margin-left: 1em;
     margin-right: 1em;
+  }
+
+  iframe {
+    border: none;
+    height: 100%;
+    width: 100%;
   }
 </style>

--- a/src/components/UrlBar.vue
+++ b/src/components/UrlBar.vue
@@ -3,6 +3,7 @@
     <input
        type="text"
        class="form-control"
+       :value="value"
        :placeholder="placeholder"
        @keyup.enter="onKeyup"
        aria-label="URL"
@@ -13,7 +14,10 @@
 <script>
   export default {
     name: "UrlBar",
-    props: { placeholder: String },
+    props: {
+      value: String,
+      placeholder: String
+    },
     methods: {
       onKeyup(event) {
         this.$emit("input", event.target.value);

--- a/tests/unit/components/Code.spec.js
+++ b/tests/unit/components/Code.spec.js
@@ -1,0 +1,90 @@
+import { expect } from "chai";
+import { mount } from "@vue/test-utils";
+import Code from "@/components/Code.vue";
+
+
+describe("Given a Code", () => {
+  let code;
+
+  beforeEach(() => {
+    code = mount(Code, {
+      propsData: { language: "", code: "" },
+      methods: {
+        highlight: (code) => "highlighted" + code
+      }
+    });
+  });
+
+  describe("When JSON is given", () => {
+    let subject;
+
+    const rawJson = `{ "foo": "bar" }`;
+    const formattedJson = `highlighted{
+  "foo": "bar"
+}`;
+
+    beforeEach(() => {
+      code.setProps({ language: "json", code: rawJson });
+      subject = code.find("pre > code");
+    });
+
+    it("Then the code should be displayed in a pre > code element", () => {
+      expect(subject.exists()).to.equal(true);
+    });
+
+    it("Then the code should be pretty print fromatted", () => {
+      expect(subject.text()).to.equal(formattedJson);
+    });
+
+    it("Then the code element should have the a 'json' css class", () => {
+      expect(subject.element.classList.contains("json")).to.equal(true);
+    });
+
+    it("Then the code element should have the a 'hljs' css class", () => {
+      expect(subject.element.classList.contains("hljs")).to.equal(true);
+    });
+  });
+
+  describe("When HTML is given", () => {
+    let subject;
+
+    const html = `<p>some html</p>`;
+
+    beforeEach(() => {
+      code.setProps({ language: "html", code: html });
+      subject = code.find("iframe");
+    });
+
+    it("Then the code should be displayed in an iframe", () => {
+      expect(subject.exists()).to.equal(true);
+    });
+
+    it("Then the iframe should contain the given html", () => {
+      expect(subject.element.getAttribute("srcdoc")).to.equal(html);
+    });
+  });
+
+  describe("When a language other than html is given", () => {
+    let subject;
+
+    const language = "not-a-language";
+    const rawCode = "some random code";
+
+    beforeEach(() => {
+      code.setProps({ language: "not-a-language", code: rawCode });
+      subject = code.find("pre > code");
+    });
+
+    it("Then the code should be displayed in a pre > code element", () => {
+      expect(subject.exists()).to.equal(true);
+    });
+
+    it("Then the code element should have css class that matches the language", () => {
+      expect(subject.element.classList.contains(language)).to.equal(true);
+    });
+
+    it("Then the code element should have the a 'hljs' css class", () => {
+      expect(subject.element.classList.contains("hljs")).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
If the Code element gets HTML, it will render it in an iframe. If it gets anything else, it will highlight the code with highlight.js. If it get JSON, it will pretty-print format the code as well. This is to make single line JSON more readable.

Issue #6 