### PR TITLE
 Sync the browser url with the UrlBar url

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,11 +20,29 @@
   export default {
     data: () => ({ url: "", body: "" }),
     components: { Code, UrlBar, WelcomeBanner },
-    watch: {
-      url(url) {
+    mounted() {
+      window.addEventListener("hashchange", this.handleHashChange);
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    },
+    beforeDestroy() {
+      window.removeEventListener("hashchange", this.handleHashChange);
+    },
+    methods: {
+      handleHashChange() {
+        const encodedUrl = window.location.hash.substring(1);
+        this.url = decodeURIComponent(encodedUrl);
+      },
+      request(url) {
         fetch(url, { headers: { Accept: "application/json" } })
           .then((response) => response.text())
           .then((body) => this.body = body);
+      }
+    },
+    watch: {
+      url(url) {
+        window.location.hash = encodeURIComponent(url);
+
+        this.request(url);
       }
     }
   };

--- a/src/components/UrlBar.vue
+++ b/src/components/UrlBar.vue
@@ -3,6 +3,7 @@
     <input
        type="text"
        class="form-control"
+       :value="value"
        :placeholder="placeholder"
        @keyup.enter="onKeyup"
        aria-label="URL"
@@ -13,7 +14,10 @@
 <script>
   export default {
     name: "UrlBar",
-    props: { placeholder: String },
+    props: {
+      value: String,
+      placeholder: String
+    },
     methods: {
       onKeyup(event) {
         this.$emit("input", event.target.value);

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -3,13 +3,30 @@ import { mount } from "@vue/test-utils";
 import App from "@/App.vue";
 import Code from "@/components/Code.vue";
 import WelcomeBanner from "@/components/WelcomeBanner.vue";
+import { wait } from "./test-utils.js";
 
 
 describe("Given an App", () => {
   let app;
 
-  beforeEach(() => {
-    app = mount(App);
+  const hashUrl = "#http%3A%2F%2Fexample.com";
+  const url = "http://example.com";
+
+  beforeEach(async () => {
+    window.location.hash = hashUrl;
+    await wait(0);
+
+    app = mount(App, {
+      data: { url },
+      methods: {
+        request: () => {}
+      }
+    });
+  });
+
+  afterEach(() => {
+    app.vm.$destroy();
+    window.location.hash = "";
   });
 
   describe("When there is no body", () => {
@@ -36,13 +53,40 @@ describe("Given an App", () => {
     });
   });
 
-  //describe("When the url is updated", () => {
-    //beforeEach(async () => {
-      //app.vm.url = "http://localhost:3000";
-    //});
+  describe("When the url is updated", () => {
+    const anotherUrl = "http://another-example.com";
+    const expectedHashUrl = "#http%3A%2F%2Fanother-example.com";
+
+    beforeEach(() => {
+      app.setData({ url: anotherUrl });
+    });
 
     //it("Then fetch the resource and put the result in body", () => {
       //expect(app.vm.body).to.equal("some-body");
     //});
-  //});
+
+    it("Then the hash location should be set to the url-encoded url", () => {
+      expect(window.location.hash).to.equal(expectedHashUrl);
+    });
+  });
+
+  describe("When the hash location exists when the component is mounted", () => {
+    it("Then the hash location should be url-decoded and update the app url", () => {
+      expect(app.vm.url).to.equal(url);
+    });
+  });
+
+  describe("When the hash location is changed after mount", () => {
+    const anotherHashUrl = "#http%3A%2F%2Fanother-example.com";
+    const expectedUrl = "http://another-example.com";
+
+    beforeEach(async () => {
+      window.location.hash = anotherHashUrl;
+      await wait(0);
+    });
+
+    it("Then it should be url-decoded and it should update the app url", () => {
+      expect(app.vm.url).to.equal(expectedUrl);
+    });
+  });
 });

--- a/tests/unit/components/UrlBar.spec.js
+++ b/tests/unit/components/UrlBar.spec.js
@@ -58,4 +58,17 @@ describe("Given a wrapper component with a UrlBar that binds to `url`", () => {
       });
     });
   });
+
+  describe("When the wrapper's url changes", () => {
+    let input;
+
+    beforeEach(() => {
+      input = wrapper.find("input");
+      wrapper.setData({ url: "some-url" });
+    });
+
+    it("Then the text in the UrlBar should update", () => {
+      expect(input.element.value).to.equal("some-url");
+    });
+  });
 });

--- a/tests/unit/test-utils.js
+++ b/tests/unit/test-utils.js
@@ -1,0 +1,4 @@
+// Use as a synchronous wait with async/await: `async () => await wait(0);`
+const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+export { wait };


### PR DESCRIPTION
The url is stored in the url fragment of the host browser. When the user changes the hash location, the UrlBar location updates. When the user changes the UrlBar location, the hash location updates.

It turned out that after changing the location hash in the tests, it was necessary to yield to allow event handlers to run. The yield was accomplished by waiting for 0 milliseconds.

An important lesson from this work is that it's important to manually call `vm.$destroy()` on any component that needs cleanup when writing tests.

Issue #4 