### PR TITLE
validate-url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -756,6 +756,7 @@
       "version": "2.0.0",
       "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
       "requires": {
         "samsam": "1.3.0"
       }
@@ -1068,15 +1069,14 @@
       "dev": true
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+      "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
       "requires": {
-        "co": "4.6.0",
         "fast-deep-equal": "1.1.0",
         "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "json-schema-traverse": "0.3.1",
+        "uri-js": "3.0.2"
       }
     },
     "ajv-keywords": {
@@ -3756,6 +3756,20 @@
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
         "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "eslint-loader": {
@@ -4049,6 +4063,20 @@
           "dev": true,
           "requires": {
             "ajv": "5.5.2"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+              "dev": true,
+              "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            }
           }
         }
       }
@@ -4062,8 +4090,7 @@
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-glob": {
       "version": "2.1.0",
@@ -4384,8 +4411,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5735,6 +5761,20 @@
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "has": {
@@ -6761,8 +6801,7 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6809,7 +6848,8 @@
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
     },
     "killable": {
       "version": "1.0.0",
@@ -7015,7 +7055,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -7053,7 +7094,8 @@
     "lolex": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -7602,6 +7644,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
       "integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
+      "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
@@ -7613,12 +7656,14 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         },
         "path-to-regexp": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
           "requires": {
             "isarray": "0.0.1"
           }
@@ -11051,7 +11096,8 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
     },
     "sax": {
       "version": "1.2.4",
@@ -11297,9 +11343,10 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.10.tgz",
-      "integrity": "sha512-GxYFgYPhuYY9RXjg6UrEE6ShiaRWM8W8EqaUCRCpqnqKfcyTcfProHZtPeZXiegMfxXKOOQhawTam66gDKVYoQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+      "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.3.1",
@@ -12003,6 +12050,20 @@
         "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "tapable": {
@@ -12014,7 +12075,8 @@
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
@@ -12486,6 +12548,21 @@
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
+    },
+    "uri-js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
+      }
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "ajv": "^6.4.0",
     "highlight.js": "^9.12.0",
     "sinon": "^4.4.10",
     "vue": "^2.5.13"
@@ -21,6 +22,7 @@
     "@vue/test-utils": "^1.0.0-beta.10",
     "chai": "^4.1.2",
     "ignore-styles": "^5.0.1",
+    "sinon": "^4.5.0",
     "vue-template-compiler": "^2.5.13"
   },
   "browserslist": [

--- a/src/components/Code.vue
+++ b/src/components/Code.vue
@@ -17,7 +17,10 @@
 
   export default {
     name: "Code",
-    props: { code: String, language: String },
+    props: {
+      code: String,
+      language: String
+    },
     methods: {
       highlight(code) {
         return hljs.highlightAuto(code).value;

--- a/src/components/UrlBar.vue
+++ b/src/components/UrlBar.vue
@@ -5,6 +5,7 @@
        class="form-control"
        :value="value"
        :placeholder="placeholder"
+       :class="{ 'is-invalid': !isUrlValid }"
        @keyup.enter="onEnter"
        aria-label="URL"
        aria-describedby="basic-addon2">
@@ -12,15 +13,34 @@
 </template>
 
 <script>
+  import { validateUri } from "../validator.js";
+
   export default {
     name: "UrlBar",
+    data: () => ({
+      isUrlValid: true
+    }),
     props: {
       value: String,
       placeholder: String
     },
     methods: {
       onEnter(event) {
+        const url = event.target.value;
+        this.isUrlValid = validateUri(url);
+
+        if (this.isUrlValid) {
+          this.$emit("make-a-request", event.target.value);
+        } else {
+          this.$emit("set-invalid-url-error-message");
+        }
+
         this.$emit("input", event.target.value);
+      }
+    },
+    watch: {
+      value(url) {
+        this.isUrlValid = validateUri(url);
       }
     }
   };

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,0 +1,13 @@
+import Ajv from "ajv";
+
+const ajv = new Ajv();
+const schema = {
+  "type": "string",
+  "format": "uri"
+};
+
+const validateUri = (uri) => {
+  return ajv.validate(schema, uri);
+};
+
+export { validateUri };

--- a/tests/unit/components/UrlBar.spec.js
+++ b/tests/unit/components/UrlBar.spec.js
@@ -22,6 +22,64 @@ Given("a UrlBar", () => {
       expect(urlBar.find("input").element.placeholder).to.equal(placeholder);
     });
   });
+
+  When("a valid URL is typed into the UrlBar", () => {
+    let input;
+
+    beforeEach(() => {
+      input = urlBar.find("input");
+
+      input.element.value = "http://www.test.com";
+    });
+
+    And("the <Enter> key is pressed in the UrlBar", () => {
+      beforeEach(() => {
+        input.trigger("keyup.enter");
+      });
+
+      Then("the input element should be registered as valid", () => {
+        const isInputValid = !input.element.classList.contains("is-invalid");
+
+        expect(isInputValid).to.be.true;
+      });
+
+      Then("two events are emitted", () => {
+        const emittedEvents = urlBar.emitted();
+        const numberOfEmittedEvents = Object.keys(emittedEvents).length;
+
+        expect(numberOfEmittedEvents).to.equal(2);
+      });
+    });
+  });
+
+  When("an invalid URL is typed into the UrlBar", () => {
+    let input;
+
+    beforeEach(() => {
+      input = urlBar.find("input");
+
+      input.element.value = "abc";
+    });
+
+    And("the <Enter> key is pressed in the UrlBar", () => {
+      beforeEach(() => {
+        input.trigger("keyup.enter");
+      });
+
+      Then("the input element should be registered as invalid", () => {
+        const isInputValid = !input.element.classList.contains("is-invalid");
+
+        expect(isInputValid).to.be.false;
+      });
+
+      Then("two events are emitted", () => {
+        const emittedEvents = urlBar.emitted();
+        const numberOfEmittedEvents = Object.keys(emittedEvents).length;
+
+        expect(numberOfEmittedEvents).to.equal(2);
+      });
+    });
+  });
 });
 
 Given("a wrapper component with a UrlBar that binds to `url`", () => {
@@ -60,7 +118,7 @@ Given("a wrapper component with a UrlBar that binds to `url`", () => {
     });
   });
 
-  When("the wrapper's url changes", () => {
+  When("the wrapper's URL changes", () => {
     let input;
 
     beforeEach(() => {
@@ -70,6 +128,18 @@ Given("a wrapper component with a UrlBar that binds to `url`", () => {
 
     Then("the text in the UrlBar should update", () => {
       expect(input.element.value).to.equal("some-url");
+    });
+
+    And("the URL is invalid", () => {
+      beforeEach(() => {
+        wrapper.setData({ url: "invalid-url" });
+      });
+
+      Then("the input element should be registered as invalid", () => {
+        const isInputValid = !input.element.classList.contains("is-invalid");
+
+        expect(isInputValid).to.be.false;
+      });
     });
   });
 });

--- a/tests/unit/validator.spec.js
+++ b/tests/unit/validator.spec.js
@@ -1,0 +1,23 @@
+import { expect } from "chai";
+import { Given, When, Then } from "./test-utils.js";
+import { validateUri } from "@/validator.js";
+
+Given("a URI", () => {
+  When("the URI is invalid", () => {
+    Then("it should return false", () => {
+      expect(validateUri("abc")).to.be.false;
+    });
+  });
+
+  When("the URI is valid", () => {
+    Then("it should return true", () => {
+      expect(validateUri("http://test.com")).to.be.true;
+    });
+  });
+
+  When("the URI is an invalid URL, but a valid URI", () => {
+    Then("it should return true", () => {
+      expect(validateUri("http://test.com-x")).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Validation has re-implemented correctly. I was able to use a `spy` for the `request` method, to test that `fetch` was called.

**Note**: I set the `invalidUrlErrorMessage` as a property in the `data` section in App, because in order to pass it in to `setErrorMessage` in the `UrlBar`, the constant needs to already be initialized.

Issue #8 