### PR TITLE
Add Gherkin syntax test helpers

### DIFF
--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -3,10 +3,10 @@ import { mount } from "@vue/test-utils";
 import App from "@/App.vue";
 import Code from "@/components/Code.vue";
 import WelcomeBanner from "@/components/WelcomeBanner.vue";
-import { wait } from "./test-utils.js";
+import { Given, When, Then, wait } from "./test-utils.js";
 
 
-describe("Given an App", () => {
+Given("an App", () => {
   let app;
 
   const hashUrl = "#http%3A%2F%2Fexample.com";
@@ -29,31 +29,31 @@ describe("Given an App", () => {
     window.location.hash = "";
   });
 
-  describe("When there is no body", () => {
-    it("Then display WelcomeBanner", () => {
+  When("there is no body", () => {
+    Then("display WelcomeBanner", () => {
       expect(app.contains(WelcomeBanner)).to.equal(true);
     });
 
-    it("Then don't display Code", () => {
+    Then("don't display Code", () => {
       expect(app.contains(Code)).to.equal(false);
     });
   });
 
-  describe("When there is a body", () => {
+  When("there is a body", () => {
     beforeEach(() => {
       app.setData({ body: "some-body" });
     });
 
-    it("Then don't display WelcomeBanner", () => {
+    Then("don't display WelcomeBanner", () => {
       expect(app.contains(WelcomeBanner)).to.equal(false);
     });
 
-    it("Then display Code", () => {
+    Then("display Code", () => {
       expect(app.contains(Code)).to.equal(true);
     });
   });
 
-  describe("When the url is updated", () => {
+  When("the url is updated", () => {
     const anotherUrl = "http://another-example.com";
     const expectedHashUrl = "#http%3A%2F%2Fanother-example.com";
 
@@ -61,22 +61,22 @@ describe("Given an App", () => {
       app.setData({ url: anotherUrl });
     });
 
-    //it("Then fetch the resource and put the result in body", () => {
+    //Then("fetch the resource and put the result in body", () => {
       //expect(app.vm.body).to.equal("some-body");
     //});
 
-    it("Then the hash location should be set to the url-encoded url", () => {
+    Then("the hash location should be set to the url-encoded url", () => {
       expect(window.location.hash).to.equal(expectedHashUrl);
     });
   });
 
-  describe("When the hash location exists when the component is mounted", () => {
-    it("Then the hash location should be url-decoded and update the app url", () => {
+  When("the hash location exists when the component is mounted", () => {
+    Then("the hash location should be url-decoded and update the app url", () => {
       expect(app.vm.url).to.equal(url);
     });
   });
 
-  describe("When the hash location is changed after mount", () => {
+  When("the hash location is changed after mount", () => {
     const anotherHashUrl = "#http%3A%2F%2Fanother-example.com";
     const expectedUrl = "http://another-example.com";
 
@@ -85,7 +85,7 @@ describe("Given an App", () => {
       await wait(0);
     });
 
-    it("Then it should be url-decoded and it should update the app url", () => {
+    Then("it should be url-decoded and it should update the app url", () => {
       expect(app.vm.url).to.equal(expectedUrl);
     });
   });

--- a/tests/unit/components/Code.spec.js
+++ b/tests/unit/components/Code.spec.js
@@ -1,9 +1,10 @@
 import { expect } from "chai";
 import { mount } from "@vue/test-utils";
 import Code from "@/components/Code.vue";
+import { Given, When, Then } from "../test-utils.js";
 
 
-describe("Given a Code", () => {
+Given("a Code", () => {
   let code;
 
   beforeEach(() => {
@@ -15,7 +16,7 @@ describe("Given a Code", () => {
     });
   });
 
-  describe("When JSON is given", () => {
+  When("JSON is given", () => {
     let subject;
 
     const rawJson = `{ "foo": "bar" }`;
@@ -28,24 +29,24 @@ describe("Given a Code", () => {
       subject = code.find("pre > code");
     });
 
-    it("Then the code should be displayed in a pre > code element", () => {
+    Then("the code should be displayed in a pre > code element", () => {
       expect(subject.exists()).to.equal(true);
     });
 
-    it("Then the code should be pretty print fromatted", () => {
+    Then("the code should be pretty print fromatted", () => {
       expect(subject.text()).to.equal(formattedJson);
     });
 
-    it("Then the code element should have the a 'json' css class", () => {
+    Then("the code element should have the a 'json' css class", () => {
       expect(subject.element.classList.contains("json")).to.equal(true);
     });
 
-    it("Then the code element should have the a 'hljs' css class", () => {
+    Then("the code element should have the a 'hljs' css class", () => {
       expect(subject.element.classList.contains("hljs")).to.equal(true);
     });
   });
 
-  describe("When HTML is given", () => {
+  When("HTML is given", () => {
     let subject;
 
     const html = `<p>some html</p>`;
@@ -55,16 +56,16 @@ describe("Given a Code", () => {
       subject = code.find("iframe");
     });
 
-    it("Then the code should be displayed in an iframe", () => {
+    Then("the code should be displayed in an iframe", () => {
       expect(subject.exists()).to.equal(true);
     });
 
-    it("Then the iframe should contain the given html", () => {
+    Then("the iframe should contain the given html", () => {
       expect(subject.element.getAttribute("srcdoc")).to.equal(html);
     });
   });
 
-  describe("When a language other than html is given", () => {
+  When("a language other than html is given", () => {
     let subject;
 
     const language = "not-a-language";
@@ -75,15 +76,15 @@ describe("Given a Code", () => {
       subject = code.find("pre > code");
     });
 
-    it("Then the code should be displayed in a pre > code element", () => {
+    Then("the code should be displayed in a pre > code element", () => {
       expect(subject.exists()).to.equal(true);
     });
 
-    it("Then the code element should have css class that matches the language", () => {
+    Then("the code element should have css class that matches the language", () => {
       expect(subject.element.classList.contains(language)).to.equal(true);
     });
 
-    it("Then the code element should have the a 'hljs' css class", () => {
+    Then("the code element should have the a 'hljs' css class", () => {
       expect(subject.element.classList.contains("hljs")).to.equal(true);
     });
   });

--- a/tests/unit/components/UrlBar.spec.js
+++ b/tests/unit/components/UrlBar.spec.js
@@ -1,29 +1,30 @@
 import { expect } from "chai";
 import { mount } from "@vue/test-utils";
 import UrlBar from "@/components/UrlBar.vue";
+import { Given, When, Then, And } from "../test-utils.js";
 
 
-describe("Given a UrlBar", () => {
+Given("a UrlBar", () => {
   let urlBar;
 
   beforeEach(() => {
     urlBar = mount(UrlBar);
   });
 
-  describe("When a placeholder is given", () => {
+  When("a placeholder is given", () => {
     const placeholder = "http://";
 
     beforeEach(() => {
       urlBar.setProps({ placeholder });
     });
 
-    it("Then it should be set as the input's placeholder", () => {
+    Then("it should be set as the input's placeholder", () => {
       expect(urlBar.find("input").element.placeholder).to.equal(placeholder);
     });
   });
 });
 
-describe("Given a wrapper component with a UrlBar that binds to `url`", () => {
+Given("a wrapper component with a UrlBar that binds to `url`", () => {
   let wrapper;
   const url = "http://example.com";
 
@@ -35,7 +36,7 @@ describe("Given a wrapper component with a UrlBar that binds to `url`", () => {
     });
   });
 
-  describe("When text is entered in the UrlBar", () => {
+  When("text is entered in the UrlBar", () => {
     let input;
 
     beforeEach(() => {
@@ -44,22 +45,22 @@ describe("Given a wrapper component with a UrlBar that binds to `url`", () => {
       input.element.value = url;
     });
 
-    it("Then `url` should not be updated to the value in the UrlBar", () => {
+    Then("`url` should not be updated to the value in the UrlBar", () => {
       expect(wrapper.vm.url).to.equal("");
     });
 
-    describe("And the <Enter> key is pressed in the UrlBar", () => {
+    And("the <Enter> key is pressed in the UrlBar", () => {
       beforeEach(() => {
         input.trigger("keyup.enter");
       });
 
-      it("Then `url` should update to the value in the UrlBar", () => {
+      Then("`url` should update to the value in the UrlBar", () => {
         expect(wrapper.vm.url).to.equal(url);
       });
     });
   });
 
-  describe("When the wrapper's url changes", () => {
+  When("the wrapper's url changes", () => {
     let input;
 
     beforeEach(() => {
@@ -67,7 +68,7 @@ describe("Given a wrapper component with a UrlBar that binds to `url`", () => {
       wrapper.setData({ url: "some-url" });
     });
 
-    it("Then the text in the UrlBar should update", () => {
+    Then("the text in the UrlBar should update", () => {
       expect(input.element.value).to.equal("some-url");
     });
   });

--- a/tests/unit/test-utils.js
+++ b/tests/unit/test-utils.js
@@ -1,4 +1,9 @@
 // Use as a synchronous wait with async/await: `async () => await wait(0);`
 const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
-export { wait };
+const Given = (message, fn) => describe("Given " + message, fn);
+const When = (message, fn) => describe("When " + message, fn);
+const Then = (message, fn) => it("Then " + message, fn);
+const And = (message, fn) => describe("And " + message, fn);
+
+export { Given, When, Then, And, wait };


### PR DESCRIPTION
Given that I have chosen to use Gherkin syntax for my tests
When I write tests
Then I should have aliases for `describe` and `it` that allow me to write readable Gherkin tests.